### PR TITLE
Improve parser text extraction and add parser tests

### DIFF
--- a/page_analyzer/parser.py
+++ b/page_analyzer/parser.py
@@ -5,12 +5,13 @@ def get_data(response):
     parsed = BeautifulSoup(response.text, "lxml")
     result: dict[str, str | None] = {}
 
-    heading = parsed.h1.string if parsed.h1 else None
-    title = parsed.title.string if parsed.title else None
+    heading = parsed.h1.get_text(strip=True) if parsed.h1 else None
+    title = parsed.title.get_text(strip=True) if parsed.title else None
     meta_desc = parsed.find("meta", {"name": "description"})
 
     result["h1"] = heading
     result["title"] = title
-    result["description"] = meta_desc.get("content") if meta_desc else None
+    meta_content = meta_desc.get("content") if meta_desc else None
+    result["description"] = meta_content.strip() if meta_content is not None else None
 
     return result

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,66 @@
+import types
+
+import pytest
+
+from page_analyzer.parser import get_data
+
+
+@pytest.mark.parametrize(
+    "html, expected",
+    [
+        pytest.param(
+            """
+            <html><head><title>Sample Title</title>
+            <meta name='description' content='Short description'></head>
+            <body><h1>Heading</h1></body></html>
+            """,
+            {"h1": "Heading", "title": "Sample Title", "description": "Short description"},
+            id="basic-elements",
+        ),
+        pytest.param(
+            """
+            <html><head><title>  Nested   Title  </title></head>
+            <body><h1><span>Nested</span><em>Heading</em></h1></body></html>
+            """,
+            {"h1": "NestedHeading", "title": "Nested   Title", "description": None},
+            id="nested-tags",
+        ),
+        pytest.param(
+            """
+            <html><head><meta name='description' content='   With surrounding spaces   '></head>
+            <body></body></html>
+            """,
+            {"h1": None, "title": None, "description": "With surrounding spaces"},
+            id="description-strip",
+        ),
+        pytest.param(
+            """
+            <html><head><title></title><meta name='description' content=''></head><body></body></html>
+            """,
+            {"h1": None, "title": "", "description": ""},
+            id="empty-values",
+        ),
+        pytest.param(
+            """
+            <html><head><title>{title}</title><meta name='description' content='{description}'></head>
+            <body><h1>{heading}</h1></body></html>
+            """.format(
+                title="T" * 300,
+                description="D" * 512,
+                heading="H" * 256,
+            ),
+            {
+                "h1": "H" * 256,
+                "title": "T" * 300,
+                "description": "D" * 512,
+            },
+            id="long-values",
+        ),
+    ],
+)
+def test_get_data_returns_expected(html, expected):
+    response = types.SimpleNamespace(text=html)
+
+    result = get_data(response)
+
+    assert result == expected


### PR DESCRIPTION
## Summary
- update the HTML parser to extract cleaned text for headings and titles while trimming meta descriptions
- add parser-focused tests covering nested tags, missing elements, empty content, and long values

## Testing
- pytest *(fails: missing optional dependencies such as flask and psycopg2)*

------
https://chatgpt.com/codex/tasks/task_b_68d62413f8d883279c08a647629a84f2