### PR TITLE
Fix formatting for Ruff compliance

### DIFF
--- a/page_analyzer/app.py
+++ b/page_analyzer/app.py
@@ -23,6 +23,7 @@ def _get_repository() -> type[UrlRepository]:
     repo_cls = getattr(app, "UrlRepository", UrlRepository)
     return repo_cls
 
+
 def _load_secret_key_from_file(path: str = ".env") -> str | None:
     try:
         with open(path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- add the missing blank line between helper functions in `page_analyzer/app.py`
- align the module with `ruff format` expectations

## Testing
- uv run ruff format --check .

------
https://chatgpt.com/codex/tasks/task_b_68de1b837a3483279c9073b66d5e13ca